### PR TITLE
party: Fix separator check [CUSTOM]

### DIFF
--- a/category.py
+++ b/category.py
@@ -6,10 +6,11 @@ from sql.operators import Equal
 from trytond.model import (
     DeactivableMixin, Exclude, ModelSQL, ModelView, fields, tree)
 
-SEPARATOR = '/'
+SEPARATOR = ' / '
 
 
-class Category(DeactivableMixin, tree(separator=' / '), ModelSQL, ModelView):
+class Category(DeactivableMixin, tree(separator=SEPARATOR), ModelSQL,
+        ModelView):
     "Category"
     __name__ = 'party.category'
     name = fields.Char(
@@ -46,12 +47,6 @@ class Category(DeactivableMixin, tree(separator=' / '), ModelSQL, ModelView):
     def validate(cls, categories):
         super(Category, cls).validate(categories)
         cls.check_recursion(categories)
-        for category in categories:
-            category.check_name()
-
-    def check_name(self):
-        if SEPARATOR in self.name:
-            self.raise_user_error('wrong_name', (self.name,))
 
     def get_rec_name(self, name):
         if self.parent:


### PR DESCRIPTION
Fix #PMETA-422

The check was wrong (obsolete `raise_user_error` + "/" instead of " / "), and it is already checked by `TreeMixin` anyway. Changing the constant only impacts the `rec_name` I think (actually a fix too for the searcher).

![Capture d’écran de 2023-04-07 14-49-23](https://user-images.githubusercontent.com/55976786/230619606-c55928a9-d36a-4117-bd2f-8ede245a0e4e.png)